### PR TITLE
Removed cloud storage emulator support

### DIFF
--- a/admin-api/delete_store.go
+++ b/admin-api/delete_store.go
@@ -16,7 +16,7 @@ func (s *ApiService) DeleteStore(context context.Context, storeId string) (opena
 		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
-	storageClient, _, err := getStorageClient(context)
+	storageClient, err := getStorageClient(context)
 	if err != nil {
 		log.Printf("Unable to create storageClient: %v", err)
 		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: "Unable to create storage client"}), err

--- a/admin-api/storage_helpers.go
+++ b/admin-api/storage_helpers.go
@@ -12,42 +12,17 @@ import (
 	"google.golang.org/api/option"
 )
 
-func getStorageEndpoint() string {
-	// This is only set when the service is configured to run against a
-	//  local emulator. When run against the real Cloud Storage APIs,
-	//  the environment variable will be empty.
-	storageEmulatorHost := os.Getenv("STORAGE_EMULATOR_HOST")
-
-	// The Firebase Storage emulator has a non-standard endpoint
-	// Normally, the API endpoint would be at http[s]://<site>:<port>/storage/v1
-	//  but the storage emulator has it at http[s]://<site>:<port>
-	// Therefore we need to specify an explicit endpoint when using the emulator
-
-	storageEndpoint := ""
-	if storageEmulatorHost != "" {
-		storageEndpoint = fmt.Sprintf("http://%s", storageEmulatorHost)
-	}
-
-	return storageEndpoint
-}
-
-func getStorageClient(context context.Context) (*storage.Client, string, error) {
-
-	storageEndpoint := getStorageEndpoint()
+func getStorageClient(context context.Context) (*storage.Client, error) {
 
 	storageClientOpts := []option.ClientOption{}
-
-	if storageEndpoint != "" {
-		storageClientOpts = append(storageClientOpts, option.WithEndpoint(storageEndpoint))
-	}
 
 	storageClient, err := storage.NewClient(context, storageClientOpts...)
 	if err != nil {
 		log.Printf("Unable to create storageClient: %v", err)
-		return nil, "", err
+		return nil, err
 	}
 
-	return storageClient, storageEndpoint, nil
+	return storageClient, nil
 }
 
 func getSymbolStoreBucketName() (string, error) {

--- a/download-api/storage_helpers.go
+++ b/download-api/storage_helpers.go
@@ -3,7 +3,6 @@ package download_api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 
@@ -11,42 +10,17 @@ import (
 	"google.golang.org/api/option"
 )
 
-func getStorageEndpoint() string {
-	// This is only set when the service is configured to run against a
-	//  local emulator. When run against the real Cloud Storage APIs,
-	//  the environment variable will be empty.
-	storageEmulatorHost := os.Getenv("STORAGE_EMULATOR_HOST")
-
-	// The Firebase Storage emulator has a non-standard endpoint
-	// Normally, the API endpoint would be at http[s]://<site>:<port>/storage/v1
-	//  but the storage emulator has it at http[s]://<site>:<port>
-	// Therefore we need to specify an explicit endpoint when using the emulator
-
-	storageEndpoint := ""
-	if storageEmulatorHost != "" {
-		storageEndpoint = fmt.Sprintf("http://%s", storageEmulatorHost)
-	}
-
-	return storageEndpoint
-}
-
-func getStorageClient(context context.Context) (*storage.Client, string, error) {
-
-	storageEndpoint := getStorageEndpoint()
+func getStorageClient(context context.Context) (*storage.Client, error) {
 
 	storageClientOpts := []option.ClientOption{}
-
-	if storageEndpoint != "" {
-		storageClientOpts = append(storageClientOpts, option.WithEndpoint(storageEndpoint))
-	}
 
 	storageClient, err := storage.NewClient(context, storageClientOpts...)
 	if err != nil {
 		log.Printf("Unable to create storageClient: %v", err)
-		return nil, "", err
+		return nil, err
 	}
 
-	return storageClient, storageEndpoint, nil
+	return storageClient, nil
 }
 
 func getSymbolStoreBucketName() (string, error) {


### PR DESCRIPTION
The local cloud storage emulators don't work well enough. Therefore, this removes support logic for them. It simplifies all logic that interacts with storage APIs.

Closes #48.