### PR TITLE
Clean up database interfacing and error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ test-local-admin-api:
 	&&	ADMIN_API_ENDPOINT="$(shell jq -r ".adminAPIEndpoint" < environments/local/config.json)" \
 		TEST_EMAIL="$(shell jq -r ".email" < environments/local/test-credentials.json)" \
 		TEST_PAT="$(shell jq -r ".pat" < environments/local/test-credentials.json)" \
-		go test -timeout 30s github.com/falldamagestudio/cloud-symbol-server/admin-api/test -count=1
+		go test -timeout 60s github.com/falldamagestudio/cloud-symbol-server/admin-api/test -count=1
 
 test-local-cli:
 	cd cli \

--- a/admin-api/create_store_upload.go
+++ b/admin-api/create_store_upload.go
@@ -33,16 +33,6 @@ func (s *ApiService) CreateStoreUpload(context context.Context, storeId string, 
 		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to determine symbol store bucket name")}), err
 	}
 
-	storeDoc, err := getStoreDoc(context, storeId)
-	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch store document for %v", storeId)}), err
-	}
-	if storeDoc == nil {
-		log.Printf("Store %v does not exist", storeId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Store %v does not exist", storeId)}), err
-	}
-
 	// Legacy API users (those who do not use the progress API) expect the response to filter
 	//  out any files that already are present; those that do use the progress API
 	//  expect to have all files listed in the response, even if they should not be uploaded

--- a/admin-api/database_helpers.go
+++ b/admin-api/database_helpers.go
@@ -32,94 +32,6 @@ func (err ErrFirestore) Unwrap() error {
 	return err.Inner
 }
 
-type ErrEntryRef interface {
-	Path() string
-}
-
-type ErrUnknown struct {
-	EntryRef ErrEntryRef
-	Inner    error
-}
-
-func (err ErrUnknown) Error() string {
-	return fmt.Sprintf("Error while accessing %v; err = %v", err.EntryRef.Path(), err.Inner)
-}
-
-func (err ErrUnknown) Unwrap() error {
-	return err.Inner
-}
-
-type ErrEntryNotFound struct {
-	EntryRef ErrEntryRef
-	Inner    error
-}
-
-func (err ErrEntryNotFound) Error() string {
-	return fmt.Sprintf("%v not found; err = %v", err.EntryRef.Path(), err.Inner)
-}
-
-func (err ErrEntryNotFound) Unwrap() error {
-	return err.Inner
-}
-
-type ErrDocToStructFailed struct {
-	EntryRef ErrEntryRef
-	Inner    error
-}
-
-func (err ErrDocToStructFailed) Error() string {
-	return fmt.Sprintf("%v document to struct conversion failed; err = %v", err.EntryRef.Path(), err.Inner)
-}
-
-func (err ErrDocToStructFailed) Unwrap() error {
-	return err.Inner
-}
-
-type ErrStoresRef struct {
-}
-
-func (ref ErrStoresRef) Path() string {
-	return fmt.Sprintf("Stores")
-}
-
-type ErrStoreRef struct {
-	StoreId string
-}
-
-func (ref ErrStoreRef) Path() string {
-	return fmt.Sprintf("Store %v", ref.StoreId)
-}
-
-type ErrStoreUploadRef struct {
-	StoreId  string
-	UploadId string
-}
-
-func (ref ErrStoreUploadRef) Path() string {
-	return fmt.Sprintf("Store %v / Upload %v", ref.StoreId, ref.UploadId)
-}
-
-type ErrStoreFileHashRef struct {
-	StoreId string
-	FileId  string
-	HashId  string
-}
-
-func (ref ErrStoreFileHashRef) Path() string {
-	return fmt.Sprintf("Store %v / Upload %v / File %v / Hash %v", ref.StoreId, ref.FileId, ref.HashId)
-}
-
-type ErrStoreFileHashUploadRef struct {
-	StoreId  string
-	FileId   string
-	HashId   string
-	UploadId string
-}
-
-func (ref ErrStoreFileHashUploadRef) Path() string {
-	return fmt.Sprintf("Store %v / Upload %v / File %v / Hash %v / Upload %v", ref.StoreId, ref.FileId, ref.HashId, ref.UploadId)
-}
-
 func runDBTransaction(ctx context.Context, f func(context.Context, *firestore.Client, *firestore.Transaction) error) error {
 
 	firestoreClient, err := firestoreClient(ctx)
@@ -162,7 +74,7 @@ func getStoreIds(ctx context.Context, client *firestore.Client) ([]string, error
 
 	storesDocSnapshots, err := client.Collection(storesCollectionName).Documents(ctx).GetAll()
 	if err != nil {
-		return nil, &ErrUnknown{EntryRef: &ErrStoresRef{}, Inner: err}
+		return nil, err
 	}
 
 	stores := make([]string, len(storesDocSnapshots))
@@ -179,7 +91,7 @@ func getStoreUploadIds(context context.Context, client *firestore.Client, storeI
 	uploadDocsIterator := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Documents(context)
 	uploadDocs, err := uploadDocsIterator.GetAll()
 	if err != nil {
-		return nil, &ErrUnknown{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
+		return nil, err
 	}
 
 	uploadIds := make([]string, len(uploadDocs))
@@ -193,41 +105,33 @@ func getStoreEntry(client *firestore.Client, tx *firestore.Transaction, storeId 
 	storeDocRef := client.Collection(storesCollectionName).Doc(storeId)
 	storeDoc, err := tx.Get(storeDocRef)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, &ErrEntryNotFound{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
-		} else {
-			return nil, &ErrUnknown{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
-		}
+		return nil, err
 	}
 
 	var storeEntry StoreEntry
 	if err = storeDoc.DataTo(&storeEntry); err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, &ErrDocToStructFailed{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
-		} else {
-			return nil, &ErrUnknown{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
-		}
+		return nil, err
 	}
 
 	return &storeEntry, nil
 }
 
+func createStoreEntry(client *firestore.Client, tx *firestore.Transaction, storeId string, storeEntry *StoreEntry) error {
+	storeUploadDocRef := client.Collection(storesCollectionName).Doc(storeId)
+	err := tx.Create(storeUploadDocRef, storeEntry)
+	return err
+}
+
 func updateStoreEntry(client *firestore.Client, tx *firestore.Transaction, storeId string, storeEntry *StoreEntry) error {
 	storeUploadDocRef := client.Collection(storesCollectionName).Doc(storeId)
 	err := tx.Set(storeUploadDocRef, storeEntry)
-	if err != nil {
-		return &ErrUnknown{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
-	}
-	return nil
+	return err
 }
 
 func createStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction, storeId string, uploadId int64, uploadContent *StoreUploadEntry) error {
 	storeUploadDocRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(fmt.Sprint(uploadId))
 	err := tx.Create(storeUploadDocRef, uploadContent)
-	if err != nil {
-		return &ErrUnknown{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: fmt.Sprint(uploadId)}, Inner: err}
-	}
-	return nil
+	return err
 }
 
 func getStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction, storeId string, uploadId string) (*StoreUploadEntry, error) {
@@ -235,20 +139,12 @@ func getStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction, st
 	storeUploadRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(uploadId)
 	storeUploadDoc, err := tx.Get(storeUploadRef)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, &ErrEntryNotFound{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
-		} else {
-			return nil, &ErrUnknown{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
-		}
+		return nil, err
 	}
 
 	var storeUploadEntry StoreUploadEntry
 	if err = storeUploadDoc.DataTo(&storeUploadEntry); err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, &ErrEntryNotFound{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
-		} else {
-			return nil, &ErrUnknown{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
-		}
+		return nil, err
 	}
 
 	return &storeUploadEntry, nil
@@ -258,41 +154,19 @@ func updateStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction,
 
 	storeUploadRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(uploadId)
 	err := tx.Set(storeUploadRef, storeUploadEntry)
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return &ErrEntryNotFound{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
-		} else {
-			return &ErrUnknown{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
-		}
-	}
-
-	return nil
+	return err
 }
 
 func updateStoreFileHashEntry(client *firestore.Client, tx *firestore.Transaction, storeId string, fileId string, hashId string, content *StoreFileHashEntry) error {
 	storeFileHashDocRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeFilesCollectionName).Doc(fileId).Collection(storeFileHashesCollectionName).Doc(hashId)
 	err := tx.Set(storeFileHashDocRef, content)
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return &ErrEntryNotFound{EntryRef: &ErrStoreFileHashRef{StoreId: storeId, FileId: fileId, HashId: hashId}, Inner: err}
-		} else {
-			return &ErrUnknown{EntryRef: &ErrStoreFileHashRef{StoreId: storeId, FileId: fileId, HashId: hashId}, Inner: err}
-		}
-	}
-	return nil
+	return err
 }
 
 func createStoreFileHashUploadEntry(client *firestore.Client, tx *firestore.Transaction, storeId string, fileId string, hashId string, uploadId int64, content *StoreFileHashUploadEntry) error {
 	storeFileHashUploadDocRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeFilesCollectionName).Doc(fileId).Collection(storeFileHashesCollectionName).Doc(hashId).Collection(storeFileHashUploadsCollectionName).Doc(fmt.Sprint(uploadId))
 	err := tx.Create(storeFileHashUploadDocRef, content)
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return &ErrEntryNotFound{EntryRef: &ErrStoreFileHashUploadRef{StoreId: storeId, FileId: fileId, HashId: hashId, UploadId: fmt.Sprint(uploadId)}, Inner: err}
-		} else {
-			return &ErrUnknown{EntryRef: &ErrStoreFileHashUploadRef{StoreId: storeId, FileId: fileId, HashId: hashId, UploadId: fmt.Sprint(uploadId)}, Inner: err}
-		}
-	}
-	return nil
+	return err
 }
 
 type DeleteDocumentsRecursiveState struct {

--- a/admin-api/database_helpers.go
+++ b/admin-api/database_helpers.go
@@ -64,30 +64,6 @@ func getStoresConfig(context context.Context) ([]string, error) {
 	return stores, nil
 }
 
-func getStoreDoc(context context.Context, storeId string) (*firestore.DocumentSnapshot, error) {
-
-	log.Printf("Fetching store document for %v", storeId)
-
-	firestoreClient, err := firestoreClient(context)
-	if err != nil {
-		log.Printf("Unable to talk to database: %v", err)
-		return nil, err
-	}
-
-	storeDoc, err := firestoreClient.Collection(storesCollectionName).Doc(storeId).Get(context)
-
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, nil
-		} else {
-			log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-			return nil, err
-		}
-	}
-
-	return storeDoc, nil
-}
-
 func getStoreUploadIds(context context.Context, storeId string) ([]string, error) {
 
 	log.Printf("Fetching all upload document IDs for %v", storeId)
@@ -110,45 +86,6 @@ func getStoreUploadIds(context context.Context, storeId string) ([]string, error
 		uploadIds[uploadDocIndex] = uploadDoc.Ref.ID
 	}
 	return uploadIds, nil
-}
-
-func getStoreUploadRef(context context.Context, storeId string, uploadId string) (*firestore.DocumentRef, error) {
-
-	log.Printf("Creating upload ref for %v/%v", storeId, uploadId)
-
-	firestoreClient, err := firestoreClient(context)
-	if err != nil {
-		log.Printf("Unable to talk to database: %v", err)
-		return nil, err
-	}
-
-	uploadRef := firestoreClient.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(uploadId)
-
-	return uploadRef, nil
-}
-
-func getStoreUploadDoc(context context.Context, storeId string, uploadId string) (*firestore.DocumentSnapshot, error) {
-
-	log.Printf("Fetching upload document for %v/%v", storeId, uploadId)
-
-	firestoreClient, err := firestoreClient(context)
-	if err != nil {
-		log.Printf("Unable to talk to database: %v", err)
-		return nil, err
-	}
-
-	uploadDoc, err := firestoreClient.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(uploadId).Get(context)
-
-	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, nil
-		} else {
-			log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-			return nil, err
-		}
-	}
-
-	return uploadDoc, nil
 }
 
 func getStoreEntry(client *firestore.Client, tx *firestore.Transaction, storeId string) (*StoreEntry, error) {

--- a/admin-api/database_helpers.go
+++ b/admin-api/database_helpers.go
@@ -117,7 +117,6 @@ func runDBTransaction(ctx context.Context, f func(context.Context, *firestore.Cl
 
 	firestoreClient, err := firestoreClient(ctx)
 	if err != nil {
-		log.Printf("Unable to talk to database: %v", err)
 		return &ErrFirestore{Inner: err}
 	}
 
@@ -127,7 +126,6 @@ func runDBTransaction(ctx context.Context, f func(context.Context, *firestore.Cl
 
 	err = firestoreClient.RunTransaction(ctx, wrappedF)
 	if err != nil {
-		log.Printf("Transaction failed: %v", err)
 		return err
 	}
 
@@ -185,7 +183,6 @@ func getStoreEntry(client *firestore.Client, tx *firestore.Transaction, storeId 
 	storeDocRef := client.Collection(storesCollectionName).Doc(storeId)
 	storeDoc, err := tx.Get(storeDocRef)
 	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
 		if status.Code(err) == codes.NotFound {
 			return nil, &ErrEntryNotFound{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
 		} else {
@@ -193,10 +190,8 @@ func getStoreEntry(client *firestore.Client, tx *firestore.Transaction, storeId 
 		}
 	}
 
-	log.Printf("Extracting store doc data")
 	var storeEntry StoreEntry
 	if err = storeDoc.DataTo(&storeEntry); err != nil {
-		log.Printf("Extracting store doc data failed")
 		if status.Code(err) == codes.NotFound {
 			return nil, &ErrDocToStructFailed{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
 		} else {
@@ -230,7 +225,6 @@ func getStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction, st
 	storeUploadRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(uploadId)
 	storeUploadDoc, err := tx.Get(storeUploadRef)
 	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
 		if status.Code(err) == codes.NotFound {
 			return nil, &ErrEntryNotFound{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
 		} else {
@@ -238,10 +232,8 @@ func getStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction, st
 		}
 	}
 
-	log.Printf("Extracting upload doc data")
 	var storeUploadEntry StoreUploadEntry
 	if err = storeUploadDoc.DataTo(&storeUploadEntry); err != nil {
-		log.Printf("Extracting upload doc data failed, err = %v", err)
 		if status.Code(err) == codes.NotFound {
 			return nil, &ErrEntryNotFound{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
 		} else {
@@ -257,7 +249,6 @@ func updateStoreUploadEntry(client *firestore.Client, tx *firestore.Transaction,
 	storeUploadRef := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Doc(uploadId)
 	err := tx.Set(storeUploadRef, storeUploadEntry)
 	if err != nil {
-		log.Printf("Unable to update store upload entry for %v/%v, err = %v", storeId, uploadId, err)
 		if status.Code(err) == codes.NotFound {
 			return &ErrEntryNotFound{EntryRef: &ErrStoreUploadRef{StoreId: storeId, UploadId: uploadId}, Inner: err}
 		} else {

--- a/admin-api/database_helpers.go
+++ b/admin-api/database_helpers.go
@@ -174,21 +174,12 @@ func getStoreIds(ctx context.Context, client *firestore.Client) ([]string, error
 	return stores, nil
 }
 
-func getStoreUploadIds(context context.Context, storeId string) ([]string, error) {
+func getStoreUploadIds(context context.Context, client *firestore.Client, storeId string) ([]string, error) {
 
-	log.Printf("Fetching all upload document IDs for %v", storeId)
-
-	firestoreClient, err := firestoreClient(context)
-	if err != nil {
-		log.Printf("Unable to talk to database: %v", err)
-		return nil, &ErrFirestore{Inner: err}
-	}
-
-	uploadDocsIterator := firestoreClient.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Documents(context)
+	uploadDocsIterator := client.Collection(storesCollectionName).Doc(storeId).Collection(storeUploadsCollectionName).Documents(context)
 	uploadDocs, err := uploadDocsIterator.GetAll()
 	if err != nil {
-		log.Printf("Error while fetching documents in %v: %v", storeId, err)
-		return nil, err
+		return nil, &ErrUnknown{EntryRef: &ErrStoreRef{StoreId: storeId}, Inner: err}
 	}
 
 	uploadIds := make([]string, len(uploadDocs))

--- a/admin-api/delete_store.go
+++ b/admin-api/delete_store.go
@@ -2,21 +2,24 @@ package admin_api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) DeleteStore(context context.Context, storeId string) (openapi.ImplResponse, error) {
+func (s *ApiService) DeleteStore(ctx context.Context, storeId string) (openapi.ImplResponse, error) {
 
-	firestoreClient, err := firestoreClient(context)
+	firestoreClient, err := firestoreClient(ctx)
 	if err != nil {
 		log.Printf("Unable to talk to database: %v", err)
 		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
-	storageClient, err := getStorageClient(context)
+	storageClient, err := getStorageClient(ctx)
 	if err != nil {
 		log.Printf("Unable to create storageClient: %v", err)
 		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: "Unable to create storage client"}), err
@@ -28,14 +31,34 @@ func (s *ApiService) DeleteStore(context context.Context, storeId string) (opena
 		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: "Unable to determine symbol store bucket name"}), err
 	}
 
-	if err = deleteAllObjectsInStore(context, storageClient, symbolStoreBucketName, storeId); err != nil {
+	// Validate that store exists
+
+	if err = runDBTransaction(ctx, func(ctx context.Context, client *firestore.Client, tx *firestore.Transaction) error {
+		var err error = nil
+		_, err = getStoreEntry(client, tx, storeId)
+		return err
+	}); err != nil {
+		var errEntryNotFound *ErrEntryNotFound
+		if errors.As(err, &errEntryNotFound) {
+			log.Printf("%v not found; err = %v", err)
+			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("%v not found", errEntryNotFound.EntryRef.Path())}), err
+		} else {
+			return openapi.Response(http.StatusInternalServerError, nil), err
+		}
+	}
+
+	// Delete all related files in Cloud Storage
+
+	if err = deleteAllObjectsInStore(ctx, storageClient, symbolStoreBucketName, storeId); err != nil {
 		if err != nil {
 			log.Printf("Unable to delete all documents in collection, err = %v", err)
 			return openapi.Response(http.StatusInternalServerError, nil), err
 		}
 	}
 
-	if err = deleteDocument(context, firestoreClient, firestoreClient.Collection(storesCollectionName).Doc(storeId), true); err != nil {
+	// Delete all related documents in Firestore
+
+	if err = deleteDocument(ctx, firestoreClient, firestoreClient.Collection(storesCollectionName).Doc(storeId), true); err != nil {
 		if err != nil {
 			log.Printf("Unable to delete document + child documents, err = %v", err)
 			return openapi.Response(http.StatusInternalServerError, nil), err

--- a/admin-api/delete_store.go
+++ b/admin-api/delete_store.go
@@ -28,15 +28,6 @@ func (s *ApiService) DeleteStore(context context.Context, storeId string) (opena
 		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: "Unable to determine symbol store bucket name"}), err
 	}
 
-	storeDoc, err := getStoreDoc(context, storeId)
-	if storeDoc == nil && err == nil {
-		log.Printf("Store does not exist")
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: "Store does not exist"}), nil
-	} else if err != nil {
-		log.Printf("Unable to fetch store doc, err = %v", err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: "Unable to fetch store doc"}), err
-	}
-
 	if err = deleteAllObjectsInStore(context, storageClient, symbolStoreBucketName, storeId); err != nil {
 		if err != nil {
 			log.Printf("Unable to delete all documents in collection, err = %v", err)

--- a/admin-api/get_store_upload.go
+++ b/admin-api/get_store_upload.go
@@ -2,6 +2,8 @@ package admin_api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -21,8 +23,12 @@ func (s *ApiService) GetStoreUpload(ctx context.Context, uploadId string, storeI
 		return err
 	})
 	if err != nil {
-		// TOOD: Smarter error handling
-		return openapi.Response(http.StatusBadRequest, nil), err
+		var errEntryNotFound *ErrEntryNotFound
+		if errors.As(err, &errEntryNotFound) {
+			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("%v not found", errEntryNotFound.EntryRef.Path())}), err
+		} else {
+			return openapi.Response(http.StatusInternalServerError, nil), err
+		}
 	}
 
 	getStoreUploadResponse := openapi.GetStoreUploadResponse{}

--- a/admin-api/get_store_upload.go
+++ b/admin-api/get_store_upload.go
@@ -2,41 +2,27 @@ package admin_api
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) GetStoreUpload(context context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
-
-	storeDoc, err := getStoreDoc(context, storeId)
-	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch store document for %v", storeId)}), err
-	}
-	if storeDoc == nil {
-		log.Printf("Store %v does not exist", storeId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Store %v does not exist", storeId)}), err
-	}
+func (s *ApiService) GetStoreUpload(ctx context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
 
 	log.Printf("Getting store upload doc")
-	storeUploadDoc, err := getStoreUploadDoc(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-	if storeUploadDoc == nil {
-		log.Printf("Upload doc %v/%v does not exist", storeId, uploadId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Upload %v/%v does not exist", storeId, uploadId)}), err
-	}
 
-	log.Printf("Extracting upload doc data")
-	var storeUploadEntry StoreUploadEntry
-	if err = storeUploadDoc.DataTo(&storeUploadEntry); err != nil {
-		log.Printf("Extracting upload doc data failed")
-		return openapi.Response(http.StatusOK, &openapi.MessageResponse{Message: "Error while extracting contents of doc"}), err
+	var storeUploadEntry *StoreUploadEntry = nil
+
+	err := runDBTransaction(ctx, func(ctx context.Context, client *firestore.Client, tx *firestore.Transaction) error {
+		var err error = nil
+		storeUploadEntry, err = getStoreUploadEntry(client, tx, storeId, uploadId)
+		return err
+	})
+	if err != nil {
+		// TOOD: Smarter error handling
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	getStoreUploadResponse := openapi.GetStoreUploadResponse{}

--- a/admin-api/get_store_upload.go
+++ b/admin-api/get_store_upload.go
@@ -2,13 +2,14 @@ package admin_api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
 
 	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *ApiService) GetStoreUpload(ctx context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
@@ -23,9 +24,8 @@ func (s *ApiService) GetStoreUpload(ctx context.Context, uploadId string, storeI
 		return err
 	})
 	if err != nil {
-		var errEntryNotFound *ErrEntryNotFound
-		if errors.As(err, &errEntryNotFound) {
-			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("%v not found", errEntryNotFound.EntryRef.Path())}), err
+		if status.Code(err) == codes.NotFound {
+			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("Upload %v / %v not found", storeId, uploadId)}), err
 		} else {
 			return openapi.Response(http.StatusInternalServerError, nil), err
 		}

--- a/admin-api/get_store_upload_ids.go
+++ b/admin-api/get_store_upload_ids.go
@@ -2,11 +2,14 @@ package admin_api
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 
 	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *ApiService) GetStoreUploadIds(ctx context.Context, storeId string) (openapi.ImplResponse, error) {
@@ -15,14 +18,24 @@ func (s *ApiService) GetStoreUploadIds(ctx context.Context, storeId string) (ope
 
 	var storeUploadIds []string = nil
 
-	err := runDBOperation(ctx, func(ctx context.Context, client *firestore.Client) error {
+	err := runDBTransaction(ctx, func(ctx context.Context, client *firestore.Client, tx *firestore.Transaction) error {
 		var err error = nil
+		_, err = getStoreEntry(client, tx, storeId)
+		if err != nil {
+			return err
+		}
+
 		storeUploadIds, err = getStoreUploadIds(ctx, client, storeId)
 		return err
 	})
 	if err != nil {
-		log.Printf("Unable to fetch all upload IDs for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, nil), err
+		if status.Code(err) == codes.NotFound {
+			log.Printf("Store %v not found: %v", err)
+			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("Store %v not found", storeId)}), err
+		} else {
+			log.Printf("Error while fetching upload IDs for store %v: %v", storeId, err)
+			return openapi.Response(http.StatusInternalServerError, nil), err
+		}
 	}
 
 	log.Printf("Response: %v", storeUploadIds)

--- a/admin-api/get_store_upload_ids.go
+++ b/admin-api/get_store_upload_ids.go
@@ -11,16 +11,6 @@ import (
 
 func (s *ApiService) GetStoreUploadIds(context context.Context, storeId string) (openapi.ImplResponse, error) {
 
-	storeDoc, err := getStoreDoc(context, storeId)
-	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch store document for %v", storeId)}), err
-	}
-	if storeDoc == nil {
-		log.Printf("Store %v does not exist", storeId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Store %v does not exist", storeId)}), err
-	}
-
 	log.Printf("Getting store upload IDs")
 	storeUploadIDs, err := getStoreUploadIds(context, storeId)
 	if err != nil {

--- a/admin-api/get_store_upload_ids.go
+++ b/admin-api/get_store_upload_ids.go
@@ -2,23 +2,30 @@ package admin_api
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) GetStoreUploadIds(context context.Context, storeId string) (openapi.ImplResponse, error) {
+func (s *ApiService) GetStoreUploadIds(ctx context.Context, storeId string) (openapi.ImplResponse, error) {
 
 	log.Printf("Getting store upload IDs")
-	storeUploadIDs, err := getStoreUploadIds(context, storeId)
+
+	var storeUploadIds []string = nil
+
+	err := runDBOperation(ctx, func(ctx context.Context, client *firestore.Client) error {
+		var err error = nil
+		storeUploadIds, err = getStoreUploadIds(ctx, client, storeId)
+		return err
+	})
 	if err != nil {
 		log.Printf("Unable to fetch all upload IDs for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch all upload IDs for %v", storeId)}), err
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
-	log.Printf("Response: %v", storeUploadIDs)
+	log.Printf("Response: %v", storeUploadIds)
 
-	return openapi.Response(http.StatusOK, storeUploadIDs), nil
+	return openapi.Response(http.StatusOK, storeUploadIds), nil
 }

--- a/admin-api/get_stores.go
+++ b/admin-api/get_stores.go
@@ -5,18 +5,27 @@ import (
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) GetStores(context context.Context) (openapi.ImplResponse, error) {
+func (s *ApiService) GetStores(ctx context.Context) (openapi.ImplResponse, error) {
 
-	stores, err := getStoresConfig(context)
+	log.Printf("Getting store upload doc")
+
+	var storeIds []string = nil
+
+	err := runDBOperation(ctx, func(ctx context.Context, client *firestore.Client) error {
+		var err error = nil
+		storeIds, err = getStoreIds(ctx, client)
+		return err
+	})
 	if err != nil {
-		log.Printf("Unable to fetch stores: %v", err)
+		log.Printf("Error while fetching stores: %v", err)
 		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
-	log.Printf("Stores: %v", stores)
+	log.Printf("Stores: %v", storeIds)
 
-	return openapi.Response(http.StatusOK, stores), nil
+	return openapi.Response(http.StatusOK, storeIds), nil
 }

--- a/admin-api/mark_store_upload_aborted.go
+++ b/admin-api/mark_store_upload_aborted.go
@@ -2,63 +2,40 @@ package admin_api
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) MarkStoreUploadAborted(context context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
+func (s *ApiService) MarkStoreUploadAborted(ctx context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
 
-	storeDoc, err := getStoreDoc(context, storeId)
-	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch store document for %v", storeId)}), err
-	}
-	if storeDoc == nil {
-		log.Printf("Store %v does not exist", storeId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Store %v does not exist", storeId)}), err
-	}
-
-	log.Printf("Getting store upload doc")
-	storeUploadDoc, err := getStoreUploadDoc(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-	if storeUploadDoc == nil {
-		log.Printf("Upload doc %v/%v does not exist", storeId, uploadId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Upload %v/%v does not exist", storeId, uploadId)}), err
-	}
-
-	log.Printf("Extracting upload doc data")
-	var storeUploadEntry StoreUploadEntry
-	if err = storeUploadDoc.DataTo(&storeUploadEntry); err != nil {
-		log.Printf("Extracting upload doc data failed")
-		return openapi.Response(http.StatusOK, &openapi.MessageResponse{Message: "Error while extracting contents of doc"}), err
-	}
-
-	log.Printf("Getting store upload ref")
-	storeUploadRef, err := getStoreUploadRef(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-
-	storeUploadEntry.Status = StoreUploadEntry_Status_Aborted
-
-	for fileIndex := range storeUploadEntry.Files {
-		file := &storeUploadEntry.Files[fileIndex]
-		if (file.Status == FileDBEntry_Status_Unknown) || (file.Status == FileDBEntry_Status_Pending) {
-			file.Status = FileDBEntry_Status_Aborted
+	err := runDBTransaction(ctx, func(ctx context.Context, client *firestore.Client, tx *firestore.Transaction) error {
+		storeUploadEntry, err := getStoreUploadEntry(client, tx, storeId, uploadId)
+		if err != nil {
+			return err
 		}
-	}
 
-	_, err = storeUploadRef.Set(context, storeUploadEntry)
+		storeUploadEntry.Status = StoreUploadEntry_Status_Aborted
+
+		for fileIndex := range storeUploadEntry.Files {
+			file := &storeUploadEntry.Files[fileIndex]
+			if (file.Status == FileDBEntry_Status_Unknown) || (file.Status == FileDBEntry_Status_Pending) {
+				file.Status = FileDBEntry_Status_Aborted
+			}
+		}
+
+		err = updateStoreUploadEntry(client, tx, storeId, uploadId, storeUploadEntry)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		log.Printf("Unable to modify status for for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to modify status document for %v/%v", storeId, uploadId)}), err
+		// TOOD: Smarter error handling
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	log.Printf("Status for %v/%v set to %v", storeId, uploadId, StoreUploadEntry_Status_Aborted)

--- a/admin-api/mark_store_upload_completed.go
+++ b/admin-api/mark_store_upload_completed.go
@@ -2,56 +2,33 @@ package admin_api
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) MarkStoreUploadCompleted(context context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
+func (s *ApiService) MarkStoreUploadCompleted(ctx context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
 
-	storeDoc, err := getStoreDoc(context, storeId)
+	err := runDBTransaction(ctx, func(ctx context.Context, client *firestore.Client, tx *firestore.Transaction) error {
+		storeUploadEntry, err := getStoreUploadEntry(client, tx, storeId, uploadId)
+		if err != nil {
+			return err
+		}
+
+		storeUploadEntry.Status = StoreUploadEntry_Status_Completed
+
+		err = updateStoreUploadEntry(client, tx, storeId, uploadId, storeUploadEntry)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch store document for %v", storeId)}), err
-	}
-	if storeDoc == nil {
-		log.Printf("Store %v does not exist", storeId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Store %v does not exist", storeId)}), err
-	}
-
-	log.Printf("Getting store upload doc")
-	storeUploadDoc, err := getStoreUploadDoc(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-	if storeUploadDoc == nil {
-		log.Printf("Upload doc %v/%v does not exist", storeId, uploadId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Upload %v/%v does not exist", storeId, uploadId)}), err
-	}
-
-	log.Printf("Extracting upload doc data")
-	var storeUploadEntry StoreUploadEntry
-	if err = storeUploadDoc.DataTo(&storeUploadEntry); err != nil {
-		log.Printf("Extracting upload doc data failed")
-		return openapi.Response(http.StatusOK, &openapi.MessageResponse{Message: "Error while extracting contents of doc"}), err
-	}
-
-	log.Printf("Getting store upload ref")
-	storeUploadRef, err := getStoreUploadRef(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-
-	storeUploadEntry.Status = StoreUploadEntry_Status_Completed
-
-	_, err = storeUploadRef.Set(context, storeUploadEntry)
-	if err != nil {
-		log.Printf("Unable to modify status for for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to modify status document for %v/%v", storeId, uploadId)}), err
+		// TOOD: Smarter error handling
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	log.Printf("Status for %v/%v set to %v", storeId, uploadId, StoreUploadEntry_Status_Completed)

--- a/admin-api/mark_store_upload_completed.go
+++ b/admin-api/mark_store_upload_completed.go
@@ -2,11 +2,14 @@ package admin_api
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 
 	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *ApiService) MarkStoreUploadCompleted(ctx context.Context, uploadId string, storeId string) (openapi.ImplResponse, error) {
@@ -27,8 +30,10 @@ func (s *ApiService) MarkStoreUploadCompleted(ctx context.Context, uploadId stri
 		return nil
 	})
 	if err != nil {
-		// TOOD: Smarter error handling
-		return openapi.Response(http.StatusBadRequest, nil), err
+		if status.Code(err) == codes.NotFound {
+			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("Upload %v / %v not found", storeId, uploadId)}), err
+		}
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
 	log.Printf("Status for %v/%v set to %v", storeId, uploadId, StoreUploadEntry_Status_Completed)

--- a/admin-api/mark_store_upload_file_uploaded.go
+++ b/admin-api/mark_store_upload_file_uploaded.go
@@ -2,56 +2,33 @@ package admin_api
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 
+	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
 )
 
-func (s *ApiService) MarkStoreUploadFileUploaded(context context.Context, uploadId string, storeId string, fileId int32) (openapi.ImplResponse, error) {
+func (s *ApiService) MarkStoreUploadFileUploaded(ctx context.Context, uploadId string, storeId string, fileId int32) (openapi.ImplResponse, error) {
 
-	storeDoc, err := getStoreDoc(context, storeId)
+	err := runDBTransaction(ctx, func(ctx context.Context, client *firestore.Client, tx *firestore.Transaction) error {
+		storeUploadEntry, err := getStoreUploadEntry(client, tx, storeId, uploadId)
+		if err != nil {
+			return err
+		}
+
+		storeUploadEntry.Files[fileId].Status = FileDBEntry_Status_Uploaded
+
+		err = updateStoreUploadEntry(client, tx, storeId, uploadId, storeUploadEntry)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		log.Printf("Unable to fetch store document for %v, err = %v", storeId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch store document for %v", storeId)}), err
-	}
-	if storeDoc == nil {
-		log.Printf("Store %v does not exist", storeId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Store %v does not exist", storeId)}), err
-	}
-
-	log.Printf("Getting store upload doc")
-	storeUploadDoc, err := getStoreUploadDoc(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-	if storeUploadDoc == nil {
-		log.Printf("Upload doc %v/%v does not exist", storeId, uploadId)
-		return openapi.Response(http.StatusNotFound, &openapi.MessageResponse{Message: fmt.Sprintf("Upload %v/%v does not exist", storeId, uploadId)}), err
-	}
-
-	log.Printf("Extracting upload doc data")
-	var storeUploadEntry StoreUploadEntry
-	if err = storeUploadDoc.DataTo(&storeUploadEntry); err != nil {
-		log.Printf("Extracting upload doc data failed")
-		return openapi.Response(http.StatusOK, &openapi.MessageResponse{Message: "Error while extracting contents of doc"}), err
-	}
-
-	log.Printf("Getting store upload ref")
-	storeUploadRef, err := getStoreUploadRef(context, storeId, uploadId)
-	if err != nil {
-		log.Printf("Unable to fetch upload document for %v/%v, err = %v", storeId, uploadId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to fetch upload document for %v/%v", storeId, uploadId)}), err
-	}
-
-	storeUploadEntry.Files[fileId].Status = FileDBEntry_Status_Uploaded
-
-	_, err = storeUploadRef.Set(context, storeUploadEntry)
-	if err != nil {
-		log.Printf("Unable to modify status for for %v/%v/%v, err = %v", storeId, uploadId, fileId, err)
-		return openapi.Response(http.StatusInternalServerError, &openapi.MessageResponse{Message: fmt.Sprintf("Unable to modify status document for %v/%v/%v", storeId, uploadId, fileId)}), err
+		// TOOD: Smarter error handling
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	log.Printf("Status for %v/%v/%v set to %v", storeId, uploadId, fileId, FileDBEntry_Status_Uploaded)

--- a/admin-api/mark_store_upload_file_uploaded.go
+++ b/admin-api/mark_store_upload_file_uploaded.go
@@ -2,11 +2,14 @@ package admin_api
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 
 	"cloud.google.com/go/firestore"
 	openapi "github.com/falldamagestudio/cloud-symbol-server/admin-api/generated/go-server/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *ApiService) MarkStoreUploadFileUploaded(ctx context.Context, uploadId string, storeId string, fileId int32) (openapi.ImplResponse, error) {
@@ -27,8 +30,10 @@ func (s *ApiService) MarkStoreUploadFileUploaded(ctx context.Context, uploadId s
 		return nil
 	})
 	if err != nil {
-		// TOOD: Smarter error handling
-		return openapi.Response(http.StatusBadRequest, nil), err
+		if status.Code(err) == codes.NotFound {
+			return openapi.Response(http.StatusNotFound, openapi.MessageResponse{Message: fmt.Sprintf("Upload %v / %v not found", storeId, uploadId)}), err
+		}
+		return openapi.Response(http.StatusInternalServerError, nil), err
 	}
 
 	log.Printf("Status for %v/%v/%v set to %v", storeId, uploadId, fileId, FileDBEntry_Status_Uploaded)

--- a/admin-api/test/store_uploads_test.go
+++ b/admin-api/test/store_uploads_test.go
@@ -25,6 +25,40 @@ func TestGetStoreUploadWithInvalidCredentialsFails(t *testing.T) {
 	}
 }
 
+func TestGetStoreUploadIdsForStoreThatDoesNotExistFails(t *testing.T) {
+
+	email, pat := getTestEmailAndPat()
+
+	authContext, apiClient := getAPIClient(email, pat)
+
+	invalidStoreId := "invalidstoreid"
+
+	_, r, err := apiClient.DefaultApi.GetStoreUploadIds(authContext, invalidStoreId).Execute()
+	desiredStatusCode := http.StatusNotFound
+	if err == nil || desiredStatusCode != r.StatusCode {
+		t.Fatalf("GetStoreUploadIds with invalid store ID is expected to give HTTP status code %v, but gave %v as response (err = %v)", desiredStatusCode, r.StatusCode, err)
+	}
+}
+
+func TestGetStoreUploadIdsForStoreExistsSucceeds(t *testing.T) {
+
+	email, pat := getTestEmailAndPat()
+
+	authContext, apiClient := getAPIClient(email, pat)
+
+	storeId := "example"
+
+	if err := ensureTestStoreExists(apiClient, authContext, storeId); err != nil {
+		t.Fatalf("ensureTestStoreExists failed: %v", err)
+	}
+
+	_, r, err := apiClient.DefaultApi.GetStoreUploadIds(authContext, storeId).Execute()
+	desiredStatusCode := http.StatusOK
+	if err != nil || desiredStatusCode != r.StatusCode {
+		t.Fatalf("GetStoreUploadIds with valid store ID is expected to give HTTP status code %v, but gave %v as response (err = %v)", desiredStatusCode, r.StatusCode, err)
+	}
+}
+
 func TestGetStoreUploadThatDoesNotExistFails(t *testing.T) {
 
 	email, pat := getTestEmailAndPat()


### PR DESCRIPTION
Firestore DB API accesses have been moved into `database_helpers.go`. The actual AdminAPI handlers work via these methods to accomplish things. There's still a bit of Firestore API visible in that transactions still are declared within the AdminAPI handlers; that is a lot harder to abstract away.

The error handling used to be a bit haphazard; it is more standardized now.